### PR TITLE
feat: 로컬스토리지 claimNo 처리 방식 개선 및 저장 후 삭제 로직 추가

### DIFF
--- a/src/main/java/com/demo/proworks/assignrule/service/impl/AssignRuleServiceImpl.java
+++ b/src/main/java/com/demo/proworks/assignrule/service/impl/AssignRuleServiceImpl.java
@@ -206,11 +206,9 @@ public class AssignRuleServiceImpl implements AssignRuleService {
 	/**
 	 * 🔥 청구를 실무자에게 배정한다. (개선된 버전)
 	 *
-	 * @process "청구 유형을 기반으로 부서명을 찾아서, 그 부서ID의 재직중인 직원만 조회해 자동 배정한다."
-	 *          1. 청구서 배정 정보 종합 조회 (한 번의 쿼리로 모든 정보 획득)
-	 *          2. 해당 부서의 재직중인 직원 수 확인
-	 *          3. 라운드로빈 방식으로 다음 배정할 직원 선택
-	 *          4. 청구서에 직원 배정
+	 * @process "청구 유형을 기반으로 부서명을 찾아서, 그 부서ID의 재직중인 직원만 조회해 자동 배정한다." 1. 청구서 배정 정보
+	 *          종합 조회 (한 번의 쿼리로 모든 정보 획득) 2. 해당 부서의 재직중인 직원 수 확인 3. 라운드로빈 방식으로 다음
+	 *          배정할 직원 선택 4. 청구서에 직원 배정
 	 * 
 	 * @param claimNo 청구 번호
 	 * @return 배정 결과 메시지
@@ -218,92 +216,130 @@ public class AssignRuleServiceImpl implements AssignRuleService {
 	 */
 	@Transactional
 	public String assignEmployeeToClaim(String claimNo) throws Exception {
-		try {
-			System.out.println("[DEBUG] 🔥 개선된 자동 배정 시작 - 청구번호: " + claimNo);
+		System.out.println("========== [DEBUG] 자동 배정 시작 ==========");
+		System.out.println("[DEBUG] 대상 청구번호: " + claimNo);
 
-			// ✅ ① 청구서 배정 정보 종합 조회 (한 번의 쿼리로 모든 정보 획득)
+		try {
+			// ✅ ① 청구서 배정 정보 종합 조회
+			System.out.println("[DEBUG] 1단계: 청구서 배정 정보 조회 시작");
 			Map<String, Object> assignmentInfo = assignRuleDAO.selectClaimAssignmentInfo(claimNo);
-			
+
 			if (assignmentInfo == null) {
+				System.err.println("[ERROR] 청구서 정보를 찾을 수 없음: " + claimNo);
 				throw new Exception("청구서 정보를 찾을 수 없습니다: " + claimNo);
 			}
+
+			System.out.println("[DEBUG] 조회된 배정 정보: " + assignmentInfo.toString());
 
 			String claimType = (String) assignmentInfo.get("CLAIM_TYPE");
 			String currentEmpNo = (String) assignmentInfo.get("CURRENT_EMP_NO");
 			String assignDeptName = (String) assignmentInfo.get("ASSIGN_DEPT_NAME");
-			// 🔥 Long에서 Integer로 안전하게 변환
 			Object targetDeptIdObj = assignmentInfo.get("TARGET_DEPT_ID");
+
+			System.out.println("[DEBUG] 파싱된 정보:");
+			System.out.println("  - 청구유형: " + claimType);
+			System.out.println("  - 현재담당자: " + currentEmpNo);
+			System.out.println("  - 대상부서명: " + assignDeptName);
+			System.out.println("  - 대상부서ID객체: " + targetDeptIdObj + " (타입: "
+					+ (targetDeptIdObj != null ? targetDeptIdObj.getClass().getSimpleName() : "null") + ")");
+
+			// 🔥 Long에서 Integer로 안전하게 변환
 			Integer targetDeptId = null;
 			if (targetDeptIdObj != null) {
 				if (targetDeptIdObj instanceof Long) {
 					targetDeptId = ((Long) targetDeptIdObj).intValue();
+					System.out.println("[DEBUG] Long -> Integer 변환: " + targetDeptId);
 				} else if (targetDeptIdObj instanceof Integer) {
 					targetDeptId = (Integer) targetDeptIdObj;
+					System.out.println("[DEBUG] Integer 유지: " + targetDeptId);
 				} else if (targetDeptIdObj instanceof String) {
 					try {
 						targetDeptId = Integer.parseInt((String) targetDeptIdObj);
+						System.out.println("[DEBUG] String -> Integer 변환: " + targetDeptId);
 					} catch (NumberFormatException e) {
-						// String이 숫자가 아닌 경우
+						System.err.println("[ERROR] String을 Integer로 변환 실패: " + targetDeptIdObj);
 					}
+				} else {
+					System.err.println("[ERROR] 알 수 없는 타입: " + targetDeptIdObj.getClass().getSimpleName());
 				}
 			}
 
-			System.out.println(String.format("[DEBUG] 종합 정보 - 청구유형: %s, 현재담당자: %s, 대상부서: %s, 부서ID: %s", 
-					claimType, currentEmpNo, assignDeptName, targetDeptId));
-
 			// 이미 배정된 청구서 체크
+			System.out.println("[DEBUG] 2단계: 기존 배정 확인");
 			if (currentEmpNo != null && !currentEmpNo.trim().isEmpty()) {
-				return "이미 배정된 청구서입니다. 청구번호: " + claimNo + ", 담당자: " + currentEmpNo;
+				String message = "이미 배정된 청구서입니다. 청구번호: " + claimNo + ", 담당자: " + currentEmpNo;
+				System.out.println("[DEBUG] " + message);
+				return message;
 			}
 
 			// 배정 규칙이 없는 경우
+			System.out.println("[DEBUG] 3단계: 배정 규칙 확인");
 			if (assignDeptName == null || targetDeptId == null) {
-				throw new Exception("청구 유형 '" + claimType + "'에 대한 배정 규칙을 찾을 수 없습니다.");
+				String error = "청구 유형 '" + claimType + "'에 대한 배정 규칙을 찾을 수 없습니다.";
+				System.err.println("[ERROR] " + error);
+				throw new Exception(error);
 			}
 
 			// ✅ ② 해당 부서의 재직중인 직원 수 확인
+			System.out.println("[DEBUG] 4단계: 부서 직원 수 확인");
+			System.out.println("[DEBUG] 조회할 부서ID: " + targetDeptId);
+
 			int employeeCount = 0;
 			try {
 				employeeCount = assignRuleDAO.selectDeptEmployeeCount(targetDeptId.toString());
+				System.out.println("[DEBUG] 부서 직원 수 조회 결과: " + employeeCount);
 			} catch (Exception e) {
 				System.err.println("[ERROR] 직원 수 조회 오류: " + e.getMessage());
+				e.printStackTrace();
 				employeeCount = 0;
 			}
-			
+
 			if (employeeCount == 0) {
-				throw new Exception("부서 '" + assignDeptName + "'에 재직중인 실무자 직원이 없습니다.");
+				String error = "부서 '" + assignDeptName + "'(ID: " + targetDeptId + ")에 재직중인 실무자 직원이 없습니다.";
+				System.err.println("[ERROR] " + error);
+				throw new Exception(error);
 			}
 
-			System.out.println("[DEBUG] 부서 " + assignDeptName + "(ID: " + targetDeptId + ")에 재직중인 직원 수: " + employeeCount);
-
 			// ✅ ③ 라운드로빈 방식으로 다음 배정할 직원 선택
+			System.out.println("[DEBUG] 5단계: 라운드로빈 직원 선택");
 			EmployeeAssignRuleVo assignedEmployee = selectNextEmployeeRoundRobin(targetDeptId.toString());
-			
+
 			if (assignedEmployee == null) {
+				System.err.println("[ERROR] 배정 가능한 직원을 찾을 수 없음");
 				throw new Exception("배정 가능한 직원을 찾을 수 없습니다.");
 			}
 
 			String empNo = String.valueOf(assignedEmployee.getEmpNo());
-			System.out.println("[DEBUG] 선택된 직원: " + assignedEmployee.getEmpName() + "(" + empNo + ")");
+			System.out.println("[DEBUG] 선택된 직원:");
+			System.out.println("  - 직원번호: " + empNo);
+			System.out.println("  - 직원명: " + assignedEmployee.getEmpName());
 
 			// ✅ ④ 청구서에 직원 배정
+			System.out.println("[DEBUG] 6단계: 청구서 업데이트");
 			Map<String, Object> updateParams = new HashMap<String, Object>();
 			updateParams.put("claimNo", claimNo);
 			updateParams.put("empNo", empNo);
-			
+
+			System.out.println("[DEBUG] 업데이트 파라미터: " + updateParams.toString());
+
 			int updateResult = assignRuleDAO.updateClaimAssignment(updateParams);
+			System.out.println("[DEBUG] 업데이트 결과: " + updateResult);
 
 			if (updateResult > 0) {
-				String result = String.format("🔥 자동 배정 완료 - 청구번호: %s, 청구유형: %s, 담당부서: %s, 담당자: %s(%s)", 
-						claimNo, claimType, assignDeptName, assignedEmployee.getEmpName(), empNo);
+				String result = String.format("🔥 자동 배정 완료 - 청구번호: %s, 청구유형: %s, 담당부서: %s, 담당자: %s(%s)", claimNo,
+						claimType, assignDeptName, assignedEmployee.getEmpName(), empNo);
 				System.out.println("[DEBUG] " + result);
+				System.out.println("========== [DEBUG] 자동 배정 성공 완료 ==========");
 				return result;
 			} else {
+				System.err.println("[ERROR] 청구 업데이트 실패 - updateResult: " + updateResult);
 				throw new Exception("청구 업데이트에 실패했습니다.");
 			}
 
 		} catch (Exception e) {
-			System.err.println("[ERROR] 🔥 자동 배정 실패 - 청구번호: " + claimNo + ", 오류: " + e.getMessage());
+			System.err.println("========== [ERROR] 자동 배정 실패 ==========");
+			System.err.println("[ERROR] 청구번호: " + claimNo);
+			System.err.println("[ERROR] 오류 메시지: " + e.getMessage());
 			e.printStackTrace();
 			throw new Exception("청구 배정 중 오류 발생: " + e.getMessage(), e);
 		}
@@ -320,24 +356,24 @@ public class AssignRuleServiceImpl implements AssignRuleService {
 			// 1. 마지막 배정된 직원 번호 조회
 			Integer lastEmpNo = employeeDAO.selectLastAssignedEmployeeInDept(deptId);
 			System.out.println("[DEBUG] 부서 " + deptId + "의 마지막 배정 직원: " + lastEmpNo);
-			
+
 			// 2. 다음 직원 조회
 			EmployeeAssignRuleVo searchVo = new EmployeeAssignRuleVo();
 			searchVo.setDeptId(deptId);
 			if (lastEmpNo != null) {
 				searchVo.setLastEmpNo(lastEmpNo.toString());
 			}
-			
+
 			EmployeeAssignRuleVo nextEmployee = employeeDAO.selectNextEmployeeForAssignment(searchVo);
-			
+
 			// 3. 다음 직원이 없으면 처음부터 다시 시작 (라운드로빈)
 			if (nextEmployee == null) {
 				nextEmployee = employeeDAO.selectFirstEmployeeInDept(deptId);
 				System.out.println("[DEBUG] 라운드로빈 순환: 부서의 첫 번째 직원으로 이동");
 			}
-			
+
 			return nextEmployee;
-			
+
 		} catch (Exception e) {
 			throw new Exception("라운드로빈 직원 선택 중 오류: " + e.getMessage(), e);
 		}
@@ -466,7 +502,7 @@ public class AssignRuleServiceImpl implements AssignRuleService {
 		try {
 			// 🔥 디버깅을 위한 직접 SQL 실행
 			System.out.println("[DEBUG]  미배정 청구 조회 시작");
-			
+
 			// 🔥 1단계: 전체 청구 수 확인 (강제로 새로운 쿼리)
 			try {
 				// 직접 SQL로 COUNT 확인
@@ -475,29 +511,29 @@ public class AssignRuleServiceImpl implements AssignRuleService {
 			} catch (Exception e) {
 				System.out.println("[DEBUG] COUNT 조회 오류: " + e.getMessage());
 			}
-			
+
 			List<ClaimVo> allClaims = claimDAO.selectListClaim(new ClaimVo());
 			System.out.println("[DEBUG] 전체 청구 수: " + (allClaims != null ? allClaims.size() : 0));
-			
-			//  각 청구의 상세 정보 출력
+
+			// 각 청구의 상세 정보 출력
 			if (allClaims != null) {
 				for (ClaimVo claim : allClaims) {
-					System.out.println(String.format("[DEBUG] 청구 상세 - NO: %s, TYPE: %s, EMP_NO: %s", 
+					System.out.println(String.format("[DEBUG] 청구 상세 - NO: %s, TYPE: %s, EMP_NO: %s",
 							claim.getClaim_no(), claim.getClaim_type(), claim.getEmp_no()));
 				}
 			}
-			
-			//  2단계: 미배정 청구 조회
+
+			// 2단계: 미배정 청구 조회
 			List<ClaimVo> unassignedClaims = assignRuleDAO.selectUnassignedClaims();
 			System.out.println("[DEBUG] 미배정 청구 수: " + (unassignedClaims != null ? unassignedClaims.size() : 0));
-			
-			//  3단계: 각 청구의 EMP_NO 상태 확인
+
+			// 3단계: 각 청구의 EMP_NO 상태 확인
 			if (allClaims != null && allClaims.size() > 0) {
 				for (int i = 0; i < Math.min(allClaims.size(), 10); i++) { // 최대 10건만 확인
 					ClaimVo claim = allClaims.get(i);
 					String empNo = claim.getEmp_no();
 					String status = "UNKNOWN";
-					
+
 					if (empNo == null) {
 						status = "NULL";
 					} else if (empNo.trim().isEmpty()) {
@@ -505,16 +541,15 @@ public class AssignRuleServiceImpl implements AssignRuleService {
 					} else {
 						status = "HAS_VALUE(" + empNo + ")";
 					}
-					
-					System.out.println(String.format("[DEBUG] 청구 %s: EMP_NO = %s", 
-							claim.getClaim_no(), status));
+
+					System.out.println(String.format("[DEBUG] 청구 %s: EMP_NO = %s", claim.getClaim_no(), status));
 				}
 			}
-			
-			//  4단계: 배정규칙 확인
+
+			// 4단계: 배정규칙 확인
 			List<AssignRuleVo> assignRules = assignRuleDAO.selectAllAssignRules();
 			System.out.println("[DEBUG] 배정규칙 수: " + (assignRules != null ? assignRules.size() : 0));
-			
+
 			List<String> results = assignAllUnassignedClaims();
 
 			int successCount = 0;
@@ -528,10 +563,10 @@ public class AssignRuleServiceImpl implements AssignRuleService {
 				}
 			}
 
-			//  성공적으로 처리되었다면 정상 메시지 반환 (예외 던지지 않음)
-			String resultMessage = String.format("배치 배정 완료 - 성공: %d건, 실패: %d건, 총: %d건", 
-					successCount, failCount, results.size());
-			
+			// 성공적으로 처리되었다면 정상 메시지 반환 (예외 던지지 않음)
+			String resultMessage = String.format("배치 배정 완료 - 성공: %d건, 실패: %d건, 총: %d건", successCount, failCount,
+					results.size());
+
 			System.out.println("[INFO] " + resultMessage);
 			return resultMessage;
 

--- a/src/main/java/com/demo/proworks/claim/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/com/demo/proworks/claim/service/impl/ClaimServiceImpl.java
@@ -133,28 +133,22 @@ public class ClaimServiceImpl implements ClaimService {
 		// 1. 청구 데이터 등록
 		int result = claimDAO.insertClaim(claimVo);
 
-		// 2. 등록이 성공한 경우 자동 배정 실행
-		if (result > 0 && claimVo.getClaim_no() != null) {
-			try {
-				// 자동 배정 설정 확인
-				String autoAssignEnabled = assignRuleService.getAutoAssignConfig();
-
-				// 자동 배정이 활성화된 경우에만 실행
-				if ("true".equals(autoAssignEnabled)) {
-					// 신규 청구에 대해 자동 배정 실행
-					String assignResult = assignRuleService.assignEmployeeToClaim(claimVo.getClaim_no());
-
-					// 배정 결과 로그 (필요시 추가 처리)
-					System.out.println("[자동 배정] " + assignResult);
-				}
-			} catch (Exception e) {
-				// 자동 배정 실패 시에도 청구 등록은 유지하고 로그만 남김
-				System.err.println("[자동 배정 실패] 청구번호: " + claimVo.getClaim_no() + ", 오류: " + e.getMessage());
-				e.printStackTrace();
-			}
-		}
-
-		return result;
+		// 2. 등록이 성공한 경우 항상 자동 배정 실행
+	    if (result > 0 && claimVo.getClaim_no() != null) {
+	        try {
+	            String assignResult = assignRuleService.assignEmployeeToClaim(claimVo.getClaim_no());
+	            // 배정 결과 로그
+	            System.out.println("[자동 배정 완료] " + assignResult);
+	        } catch (Exception e) {
+	            // 자동 배정 실패 시에도 청구 등록은 유지하고 로그만 남김
+	            System.err.println("[자동 배정 실패] 청구번호: " + claimVo.getClaim_no() + ", 오류: " + e.getMessage());
+	            e.printStackTrace();
+	            // 🔥 선택사항: 자동배정 실패시 예외를 던져서 전체 트랜잭션을 롤백하려면 아래 주석 해제
+	            // throw new Exception("자동 배정 실패: " + e.getMessage(), e);
+	        }
+	    }
+	
+	    return result;
 	}
 
 	/**
@@ -208,7 +202,12 @@ public class ClaimServiceImpl implements ClaimService {
 		claimVo.setDate_of_accident(accidentDateStr);
 
 		// 자동 생성된 claimDao.insertClaim 메소드 호출
-		claimDAO.insertClaim(claimVo);
+//		claimDAO.insertClaim(claimVo);
+		int insertResult = this.insertClaim(claimVo);
+
+		if (insertResult <= 0) {	
+			throw new Exception("청구 정보 저장에 실패했습니다.");
+		}
 		
 		System.out.println("CLAIM 테이블 저장 완료: " + claimVo.getClaim_no());
 

--- a/src/main/webapp/ui/Assignment/claimReturnPopup.xml
+++ b/src/main/webapp/ui/Assignment/claimReturnPopup.xml
@@ -31,9 +31,11 @@
         <w2:publicInfo method=""/>
         <script lazy="false" type="text/javascript"><![CDATA[
 scwin.onpageload = function () {
-    var claim_no = localStorage.getItem("claim_no");
-    txt_claim_no.setValue(claim_no);
-    dma_additionalReq.set("claim_no", claim_no);
+
+    scwin.claim = JSON.parse(localStorage.getItem("claim"));
+
+    txt_claim_no.setValue(scwin.claim.claimNo);
+    dma_additionalReq.set("claim_no", scwin.claim.claimNo);
 };
 
 // 추가요청 등록 및 상태 업데이트

--- a/src/main/webapp/ui/Assignment/reqSupplePopup.xml
+++ b/src/main/webapp/ui/Assignment/reqSupplePopup.xml
@@ -26,9 +26,10 @@
         <w2:publicInfo method=""/>
         <script lazy="false" type="text/javascript"><![CDATA[
 scwin.onpageload = function() {
-    var claim_no = localStorage.getItem("claim_no");
-    txt_req_supple.setValue(claim_no);
-    dma_additionalReq.set("claim_no", claim_no);
+    scwin.claim = JSON.parse(localStorage.getItem("claim"));
+
+    txt_req_supple.setValue(scwin.claim.claimNo);
+    dma_additionalReq.set("claim_no", scwin.claim.claimNo);
 };
 
 // 보완요청 등록 및 상태 업데이트

--- a/src/main/webapp/ui/audit/insure-result.xml
+++ b/src/main/webapp/ui/audit/insure-result.xml
@@ -236,7 +236,7 @@
 			</xf:submission>
 
 			<!-- 정산정보 업데이트 -->
-			<xf:submission id="sbm_updateSettlement" ref='data:json,dma_settlementInfo' target='data:json,dma_result'
+			<xf:submission id="sbm_updateSettlement" ref='data:json,{"id":"dma_settlementInfo","key":"settlementVo"}' target='data:json,dma_result'
 				action="/InsWebApp/SETTLEMENTUpd.pwkjson" method="post" mediatype="application/json" mode="asynchronous">
 			</xf:submission>
 
@@ -503,25 +503,14 @@ scwin.showLoading = function (show) {
 };
 
 scwin.onpageload = function () {
-    /*     const claim = {
-            claimNo: rowData.claim_no,
-            ID: rowData.ID,
-            empName: rowData.empName,
-            userName: rowData.user_name,
-            status: rowData.status
-        }; */
-    // localStorage.setItem("claim_no", "a52d86a3-5629-11f0-b4f3-bc2411231130");
-    // var claimNo = localStorage.getItem("claim_no");
-    localStorage.setItem("claim", JSON.stringify(claim));
     scwin.claim = JSON.parse(localStorage.getItem("claim"));
     // 로컬스토리지에서 가져오기
-    const claimNo = scwin.claim.claimNo;
-    console.log("청구번호:", claimNo);
+    console.log("청구번호:", scwin.claim.claimNo);
     // 검색 조건에 설정
-    dma_search.set("claim_no", claimNo);
-    dma_excludedItemsSearch.set("SC_claim_no", claimNo);
+    dma_search.set("claim_no", scwin.claim.claimNo);
+    dma_excludedItemsSearch.set("SC_claim_no", scwin.claim.claimNo);
     // 페이징 정보 설정
-    dmp_settlementVo.set("SC_claim_no", claimNo);
+    dmp_settlementVo.set("SC_claim_no", scwin.claim.claimNo);
 
     // 데이터 조회
     scwin.loadClaimUserEmpInfo();
@@ -535,8 +524,8 @@ scwin.onpageload = function () {
 scwin.loadExistingMemo = function () {
     console.log("메모 불러오기")
     // 로컬스토리지에서 가져오기
-    if (claimNo) {
-        dma_claimResult.set("claim_no", claimNo);
+    if (scwin.claim.claimNo) {
+        dma_claimResult.set("claim_no", scwin.claim.claimNo);
         console.log("메모 불러오기 서브미션 실 행")
         $p.executeSubmission("sbm_selectClaimResult");
     } else {
@@ -545,11 +534,11 @@ scwin.loadExistingMemo = function () {
     }
 };
 scwin.sbm_selectSettlementTreatment = function () {
-    if (!claimNo) {
+    if (!scwin.claim.claimNo) {
         alert("청구번호가 설정되지 않았습니다.")
         return;
     }
-    dma_settlementTreatmentSearch.set("SC_claim_no", claimNo);
+    dma_settlementTreatmentSearch.set("SC_claim_no", scwin.claim.claimNo);
 
     try {
         $p.executeSubmission("sbm_selectSettlementTreatment");
@@ -567,8 +556,8 @@ scwin.searchSettlementData = function () {
 scwin.searchExcludedItems = function () {
 
 
-    dma_excludedItemsSearch.set("SC_claim_no", claimNo);
-    dma_excludedItemsSearch.set("claim_no", claimNo); // 백업 파라미터
+    dma_excludedItemsSearch.set("SC_claim_no", scwin.claim.claimNo);
+    dma_excludedItemsSearch.set("claim_no", scwin.claim.claimNo); // 백업 파라미터
     //청구 번호 없으면 
     if (!dma_excludedItemsSearch.get("claim_no")) {
         console.log("제외항목 조회 스킵 - 청구번호 없음");
@@ -579,13 +568,13 @@ scwin.searchExcludedItems = function () {
 
     // dma_excludedItemsSearch가 정의되어 있는지 확인
     if (typeof dma_excludedItemsSearch !== 'undefined') {
-        dma_excludedItemsSearch.set("SC_claim_no", claimNo);
-        dma_excludedItemsSearch.set("claim_no", claimNo); // 백업 파라미터
+        dma_excludedItemsSearch.set("SC_claim_no", scwin.claim.claimNo);
+        dma_excludedItemsSearch.set("claim_no", scwin.claim.claimNo); // 백업 파라미터
     } else {
 
         // 대안: 기존 dma_search 사용
         if (typeof dma_search !== 'undefined') {
-            dma_search.set("claim_no", claimNo);
+            dma_search.set("claim_no", scwin.claim.claimNo);
         } else {
             scwin.calculateTotalExcludedAmount();
             scwin.searchInsuranceProducts();
@@ -778,7 +767,7 @@ scwin.searchInsuranceProducts = function () {
 
 // FastAPI 심사메모 생성 - claim_no 기준으로 수정
 scwin.generateMemoFromAPI = function () {
-    if (!claimNo) {
+    if (!scwin.claim.claimNo) {
         alert("청구번호를 확인해주세요.");
         return;
     }
@@ -873,7 +862,7 @@ scwin.prepareFastAPIRequestData = function () {
                     deducation_amt: parseInt(dlt_settlementTreatmentList.getCellData(i, "deducation_amt") || "0"),
                     refund_amt: parseInt(dlt_settlementTreatmentList.getCellData(i, "refund_amt") || "0"),
                     treatment_id: parseInt(dlt_settlementTreatmentList.getCellData(i, "treatment_id")),
-                    claim_no: claimNo
+                    claim_no: scwin.claim.claimNo
                 };
                 settlements.push(settlement);
                 console.log("정산[" + i + "]:", settlement);
@@ -887,7 +876,7 @@ scwin.prepareFastAPIRequestData = function () {
                 deducation_amt: parseInt(dma_settlementInfo.get("deducation_amt") || "10000"),
                 refund_amt: parseInt(dma_settlementInfo.get("refund_amt") || "75000"),
                 treatment_id: 1,
-                claim_no: claimNo
+                claim_no: scwin.claim.claimNo
             });
         }
 
@@ -899,7 +888,7 @@ scwin.prepareFastAPIRequestData = function () {
             for (var j = 0; j < settlementRowCount; j++) {
                 var treatment = {
                     treatment_id: parseInt(dlt_settlementTreatmentList.getCellData(j, "treatment_id")),
-                    claim_no: claimNo,
+                    claim_no: scwin.claim.claimNo,
                     department: dlt_settlementTreatmentList.getCellData(j, "department") || "일반",
                     treatment_date: dlt_settlementTreatmentList.getCellData(j, "treatment_date") || new Date().toISOString().split('T')[0],
                     patient_type: "일반",
@@ -913,7 +902,7 @@ scwin.prepareFastAPIRequestData = function () {
             console.log("기본 치료 데이터 생성");
             treatments.push({
                 treatment_id: 1,
-                claim_no: claimNo,
+                claim_no: scwin.claim.claimNo,
                 department: "내과",
                 treatment_date: new Date().toISOString().split('T')[0],
                 patient_type: "일반",
@@ -953,7 +942,7 @@ scwin.prepareFastAPIRequestData = function () {
                 exc_id: parseInt(excId || (l + 1)),
                 item_id: parseInt(dlt_excludedItems.getCellData(l, "item_id") || "0"),
                 treatment_id: parseInt(treatmentId || treatments[0]?.treatment_id || 1),
-                claim_no: claimNo,
+                claim_no: scwin.claim.claimNo,
                 exc_reason: excReason || "",
                 exc_cost: parseInt(excCost || "0"),
                 exc_category: excCategory || ""
@@ -971,7 +960,7 @@ scwin.prepareFastAPIRequestData = function () {
         };
 
         console.log("=== 준비된 요청 데이터 최종 통계 ===");
-        console.log("- claim_no: " + claimNo);
+        console.log("- claim_no: " + scwin.claim.claimNo);
         console.log("- settlements: " + settlements.length + "건");
         console.log("- treatments: " + treatments.length + "건");
         console.log("- excluded_items: " + excludedItems.length + "건");
@@ -1080,48 +1069,6 @@ scwin.sbm_generateMemo_submiterror = function (e) {
     alert(errorMsg);
 };
 
-// 최종 심사 완료
-scwin.btn_complete_onclick = function () {
-    var memo = txt_examMemo.getValue();
-
-    if (!memo || memo.trim() === "") {
-        alert("심사 메모를 먼저 생성해주세요.");
-        return;
-    }
-
-    if (confirm("최종 심사를 완료하시겠습니까?")) {
-        // 상태 업데이트
-        dma_settlementInfo.set("status", "심사완료");
-
-        // 서버에 업데이트
-        scwin.showLoading(true);
-        $p.executeSubmission("sbm_updateSettlement", {
-            success: function (e) {
-                scwin.showLoading(false);
-
-                // 보험 상품 상태 업데이트
-                var rowCount = dlt_insuranceProducts.getRowCount();
-                for (var i = 0; i < rowCount; i++) {
-                    dlt_insuranceProducts.setCellData(i, "status", "지급완료");
-                }
-
-                // 상태 배지 업데이트
-                spn_status.removeClass("status_pending");
-                spn_status.addClass("status_completed");
-                spn_status.setValue("심사완료");
-
-                alert("심사가 완료되었습니다.");
-
-                location.href="/InsWebApp/websquare/websquare.html?w2xPath=/InsWebApp/ui/webWrapper.xml"
-            },
-            error: function (e) {
-                scwin.showLoading(false);
-                dma_settlementInfo.set("status", "심사중");
-                alert("심사 완료 처리 중 오류가 발생했습니다.");
-            }
-        });
-    }
-};
 
 // 4. 정산 상세 조회 오류 처리 콜백 추가
 scwin.sbm_selectSettlement_submiterror = function (e) {
@@ -1143,11 +1090,11 @@ scwin.sbm_selectSettlement_submiterror = function (e) {
 // 유저 정보 불러오기 
 scwin.loadClaimUserEmpInfo = function (e) {
 
-    if (!claimNo) {
+    if (!scwin.claim.claimNo) {
         alert("저장된 청구번호가 없습니다.");
         return;
     }
-    dma_claimNoVo.set("claim_no", claimNo);
+    dma_claimNoVo.set("claim_no", scwin.claim.claimNo);
 
     $p.executeSubmission("sbm_selectClaimUserEmpInfo");
 };
@@ -1164,14 +1111,14 @@ scwin.prepareClaimResultData = function () {
         String(currentDate.getDate()).padStart(2, '0');
 
     // CLAIM_RESULT 데이터 설정
-    dma_claimResult.set("claim_no", claimNo);
+    dma_claimResult.set("claim_no", scwin.claim.claimNo);
     dma_claimResult.set("claim_memo", memo.trim());
     dma_claimResult.set("amount", refundAmount);
     dma_claimResult.set("date", formattedDate);
 
 
     return {
-        claim_no: claimNo,
+        claim_no: scwin.claim.claimNo,
         memo: memo.trim(),
         amount: refundAmount,
         date: formattedDate
@@ -1187,8 +1134,8 @@ scwin.btn_complete_onclick = function () {
         return;
     }
 
-    var claimNo = dma_search.get("claim_no");
-    if (!claimNo) {
+    // var claimNo = dma_search.get("claim_no");
+    if (!scwin.claim.claimNo) {
         alert("청구번호가 없습니다.");
         return;
     }
@@ -1204,11 +1151,11 @@ scwin.btn_complete_onclick = function () {
     )) {
         scwin.showLoading(true);
 
-        // 1단계: settlement 상태 변경
-        dma_settlementInfo.set("status", "심사완료");
 
         // 2단계: CLAIM_RESULT 테이블에 저장
         $p.executeSubmission("sbm_saveClaimResult");
+        localStorage.removeItem("claim");
+        location.href="/InsWebApp/websquare/websquare.html?w2xPath=/InsWebApp/ui/webWrapper.xml"
     }
 };
 
@@ -1221,27 +1168,12 @@ scwin.sbm_saveClaimResult_submitdone = function (e) {
     if (elHeader && elHeader.resSuc !== false) {
         // 저장 성공
         console.log("CLAIM_RESULT 저장 성공");
-
-        // 정산 정보도 업데이트 (심사완료 상태인 경우)
-        var currentStatus = dma_settlementInfo.get("status");
-        if (currentStatus === "심사완료") {
-            scwin.updateSettlementStatus();
-        } else {
-            scwin.showLoading(false);
-            alert("메모가 성공적으로 저장되었습니다.");
-        }
-
     } else {
         // 저장 실패
         scwin.showLoading(false);
         var errorMsg = elHeader && elHeader.resMsg ? elHeader.resMsg : "저장에 실패했습니다.";
         console.error("CLAIM_RESULT 저장 실패:", errorMsg);
         alert("CLAIM_RESULT 저장 실패: " + errorMsg);
-
-        // 심사완료 상태였다면 되돌리기
-        if (dma_settlementInfo.get("status") === "심사완료") {
-            dma_settlementInfo.set("status", "심사중");
-        }
     }
 };
 
@@ -1299,40 +1231,37 @@ scwin.sbm_updateClaimResult_submiterror = function (e) {
 };
 
 // 정산 정보 상태 업데이트 함수
-scwin.updateSettlementStatus = function () {
-    console.log("정산 정보 상태 업데이트 시작");
+// scwin.updateSettlementStatus = function () {
+//     console.log("정산 정보 상태 업데이트 시작");
 
-    // 정산 정보 업데이트 submission 실행
-    $p.executeSubmission("sbm_updateSettlement", {
-        success: function (e) {
-            scwin.showLoading(false);
+//     // 정산 정보 업데이트 submission 실행
+//     $p.executeSubmission("sbm_updateSettlement", {
+//         success: function (e) {
+//             console.log("정산 정보 업데이트 성공");
 
-            console.log("정산 정보 업데이트 성공");
+//             // 보험 상품 상태 업데이트
+//             var rowCount = dlt_insuranceProducts.getRowCount();
+//             for (var i = 0; i < rowCount; i++) {
+//                 dlt_insuranceProducts.setCellData(i, "status", "지급완료");
+//             }
 
-            // 보험 상품 상태 업데이트
-            var rowCount = dlt_insuranceProducts.getRowCount();
-            for (var i = 0; i < rowCount; i++) {
-                dlt_insuranceProducts.setCellData(i, "status", "지급완료");
-            }
+//             // 상태 배지 업데이트
+//             spn_status.removeClass("status_pending");
+//             spn_status.addClass("status_completed");
+//             spn_status.setValue("심사완료");
 
-            // 상태 배지 업데이트
-            spn_status.removeClass("status_pending");
-            spn_status.addClass("status_completed");
-            spn_status.setValue("심사완료");
+//             alert("심사가 완료되었습니다.\nCLAIM_RESULT 테이블에 결과가 저장되었습니다.");
+//         },
+//         error: function (e) {
+//             scwin.showLoading(false);
+//             console.error("정산 정보 업데이트 실패:", e);
 
-            alert("심사가 완료되었습니다.\nCLAIM_RESULT 테이블에 결과가 저장되었습니다.");
-        },
-        error: function (e) {
-            scwin.showLoading(false);
-            console.error("정산 정보 업데이트 실패:", e);
-
-            // 상태는 되돌리지만 CLAIM_RESULT는 이미 저장됨
-            dma_settlementInfo.set("status", "심사중");
-            alert("CLAIM_RESULT는 저장되었지만, 정산 정보 업데이트에 실패했습니다.");
-        }
-    });
-};
-
+//             // 상태는 되돌리지만 CLAIM_RESULT는 이미 저장됨
+//             dma_settlementInfo.set("status", "심사중");
+//             alert("CLAIM_RESULT는 저장되었지만, 정산 정보 업데이트에 실패했습니다.");
+//         }
+//     });
+// };
 
 
 // 1. 수정된 콜백 함수 - 서버 응답에 따른 데이터 처리
@@ -1425,14 +1354,14 @@ scwin.sbm_selectSettlementTreatment_submitdone = function (e) {
 
 // 1. 수정된 정산집계 조회 함수
 scwin.sbm_selectSettlementSummary = function () {
-    if (!claimNo) {
+    if (!scwin.claim.claimNo) {
         console.error("청구번호가 없습니다.")
         alert("청구번호가 설정되지 않았습니다.")
         return;
     }
 
     //  파라미터명 확인 (SC_claim_no vs claim_no)
-    dma_settlementSummarySearch.set("SC_claim_no", claimNo);
+    dma_settlementSummarySearch.set("SC_claim_no", scwin.claim.claimNo);
     console.log("dma : ", dma_settlementSummarySearch);
     console.log("요청 데이터:", dma_settlementSummarySearch.getJSON());
 

--- a/src/main/webapp/ui/audit/insure-result.xml
+++ b/src/main/webapp/ui/audit/insure-result.xml
@@ -1230,39 +1230,6 @@ scwin.sbm_updateClaimResult_submiterror = function (e) {
     alert("CLAIM_RESULT 업데이트 중 오류가 발생했습니다.");
 };
 
-// 정산 정보 상태 업데이트 함수
-// scwin.updateSettlementStatus = function () {
-//     console.log("정산 정보 상태 업데이트 시작");
-
-//     // 정산 정보 업데이트 submission 실행
-//     $p.executeSubmission("sbm_updateSettlement", {
-//         success: function (e) {
-//             console.log("정산 정보 업데이트 성공");
-
-//             // 보험 상품 상태 업데이트
-//             var rowCount = dlt_insuranceProducts.getRowCount();
-//             for (var i = 0; i < rowCount; i++) {
-//                 dlt_insuranceProducts.setCellData(i, "status", "지급완료");
-//             }
-
-//             // 상태 배지 업데이트
-//             spn_status.removeClass("status_pending");
-//             spn_status.addClass("status_completed");
-//             spn_status.setValue("심사완료");
-
-//             alert("심사가 완료되었습니다.\nCLAIM_RESULT 테이블에 결과가 저장되었습니다.");
-//         },
-//         error: function (e) {
-//             scwin.showLoading(false);
-//             console.error("정산 정보 업데이트 실패:", e);
-
-//             // 상태는 되돌리지만 CLAIM_RESULT는 이미 저장됨
-//             dma_settlementInfo.set("status", "심사중");
-//             alert("CLAIM_RESULT는 저장되었지만, 정산 정보 업데이트에 실패했습니다.");
-//         }
-//     });
-// };
-
 
 // 1. 수정된 콜백 함수 - 서버 응답에 따른 데이터 처리
 scwin.sbm_selectSettlementTreatment_submitdone = function (e) {


### PR DESCRIPTION

- claimNo를 로컬스토리지에서 가져오는 방식을 구조화
- CLAIM_RESULT 저장 후 localStorage에서 claim 관련 데이터 제거
- localStorage.setItem 관련 예외 상황 수정
- AssignRule 관련 기능 수정
- insure-result 내 불필요한 주석 제거로 코드 정리
