### PR TITLE
fix : role에 따른 버튼 처리

### DIFF
--- a/src/main/webapp/ui/audit/insure-result.xml
+++ b/src/main/webapp/ui/audit/insure-result.xml
@@ -618,6 +618,8 @@ scwin.setUIPermissions = function () {
             btn_supplement.show();
             btn_approval.show();
             btn_complete.show();
+            btn_approve_complete.hide();  // 관리자용 버튼 숨김
+            btn_reject.hide();           // 관리자용 버튼 숨김
             btn_generateMemo.show();
 
             txt_examMemo.setReadOnly(false);
@@ -630,6 +632,8 @@ scwin.setUIPermissions = function () {
             btn_supplement.show();
             btn_approval.show();
             btn_complete.show();
+            btn_approve_complete.hide();  // 관리자용 버튼 숨김
+            btn_reject.hide();           // 관리자용 버튼 숨김
             btn_generateMemo.show();
 
             // 모든 버튼 비활성화
@@ -656,11 +660,28 @@ scwin.setUIPermissions = function () {
         btn_return.hide();
         btn_supplement.hide();
         btn_generateMemo.hide();
-        btn_complete.hide();
+        btn_complete.hide();  // 실무자용 완료 버튼 숨김
+        btn_approval.hide();  // 결재 신청/승인 버튼 숨김
+        
+        // 관리자용 버튼들 표시
+        btn_approve_complete.show();
         btn_reject.show();
+        
+        // 결재중 상태에서만 두 버튼 모두 활성화
+        if (claimStatus === "결재중") {
+            btn_approve_complete.setDisabled(false);
+            btn_approve_complete.removeClass("disabled-button");
+            btn_reject.setDisabled(false);
+            btn_reject.removeClass("disabled-button");
+        } else {
+            // 다른 모든 상태에서는 비활성화
+            btn_approve_complete.setDisabled(true);
+            btn_approve_complete.addClass("disabled-button");
+            btn_reject.setDisabled(true);
+            btn_reject.addClass("disabled-button");
+        }
 
         txt_examMemo.setReadOnly(true);
-        btn_approval.setValue("결재 승인");
     }
 };
 
@@ -1804,7 +1825,14 @@ scwin.sbm_approveApprovalReq_submitdone = function (e) {
     var responseData = e.responseJSON;
     var elHeader = responseData ? responseData.elHeader : null;
     console.log(e);
+    
+    scwin.showLoading(false);  // 로딩 종료
+    
     if (elHeader && elHeader.resSuc !== false) {
+        // 로컬 스토리지의 claim 상태 업데이트
+        scwin.claim.status = "결재완료";
+        localStorage.setItem("claim", JSON.stringify(scwin.claim));
+        
         Swal.fire({
             title: '승인 완료',
             text: '결재승인이 완료되었습니다.',
@@ -1828,6 +1856,8 @@ scwin.sbm_approveApprovalReq_submitdone = function (e) {
 
 // 결재승인 에러 콜백
 scwin.sbm_approveApprovalReq_submiterror = function (e) {
+    scwin.showLoading(false);  // 로딩 종료
+    
     console.error("=== 결재승인 오류 ===");
     console.error("오류 객체:", e);
     console.error("상태 코드:", e.status);
@@ -1846,7 +1876,14 @@ scwin.sbm_approveApprovalReq_submiterror = function (e) {
             errorMsg += "\n" + e.responseText;
         }
     }
-    alert(errorMsg);
+    
+    Swal.fire({
+        title: '에러 발생',
+        text: errorMsg,
+        icon: 'error',
+        confirmButtonText: '확인',
+        confirmButtonColor: '#3085d6'
+    });
 };
 scwin.btn_return_onclick = function (e) {
     // 기본 권한 체크
@@ -2143,6 +2180,9 @@ scwin.setStatusBasedPermissions = function (status) {
             btn_approval.setDisabled(false);
             btn_approval.removeClass("disabled-button");
 
+            btn_complete.setDisabled(false);  // 결재반려 상태에서도 심사완료 가능
+            btn_complete.removeClass("disabled-button");
+
             btn_generateMemo.setDisabled(false);
             btn_generateMemo.removeClass("disabled-button");
 
@@ -2184,9 +2224,12 @@ scwin.setStatusBasedPermissions = function (status) {
             btn_return.setDisabled(true);
             btn_return.addClass("disabled-button");
 
-            // 결재신청과 메모 생성은 가능
+            // 결재신청과 메모 생성, 심사완룼도 가능
             btn_approval.setDisabled(false);
             btn_approval.removeClass("disabled-button");
+
+            btn_complete.setDisabled(false);  // 보완/반송 상태에서도 심사완료 가능
+            btn_complete.removeClass("disabled-button");
 
             btn_generateMemo.setDisabled(false);
             btn_generateMemo.removeClass("disabled-button");
@@ -2196,7 +2239,7 @@ scwin.setStatusBasedPermissions = function (status) {
         }
 
     } else if (status === "대기") {
-        // 대기 상태: 모든 작업 가능
+        // 대기 상태: 모든 작업 가능 (심사완료 포함)
         console.log("대기 상태 - 모든 작업 가능");
 
         if (scwin.employee.role === "실무자" && scwin.claim.empNo === scwin.employee.empNo) {
@@ -2208,6 +2251,9 @@ scwin.setStatusBasedPermissions = function (status) {
 
             btn_approval.setDisabled(false);
             btn_approval.removeClass("disabled-button");
+
+            btn_complete.setDisabled(false);  // 대기 상태에서도 심사완료 가능
+            btn_complete.removeClass("disabled-button");
 
             btn_generateMemo.setDisabled(false);
             btn_generateMemo.removeClass("disabled-button");
@@ -2240,6 +2286,23 @@ scwin.setStatusBasedPermissions = function (status) {
 
     // 상태 정보 표시 업데이트
     scwin.updateStatusInfo(status);
+    
+    // 관리자 권한 재설정 (상태별 권한 후에 실행)
+    if (scwin.employee && scwin.employee.role !== "실무자") {
+        if (status === "결재중") {
+            // 결재중 상태에서는 관리자 버튼들 활성화
+            btn_approve_complete.setDisabled(false);
+            btn_approve_complete.removeClass("disabled-button");
+            btn_reject.setDisabled(false);
+            btn_reject.removeClass("disabled-button");
+        } else {
+            // 다른 상태에서는 관리자 버튼들 비활성화
+            btn_approve_complete.setDisabled(true);
+            btn_approve_complete.addClass("disabled-button");
+            btn_reject.setDisabled(true);
+            btn_reject.addClass("disabled-button");
+        }
+    }
 };
 // 상태 정보 업데이트 함수 추가
 scwin.updateStatusInfo = function (status) {
@@ -2474,7 +2537,70 @@ scwin.checkApprovalPermission = function () {
 //     }
 
 //     return true;
-// };]]></script>
+// };
+
+// 관리자용 결재 완료 버튼 클릭 함수 (상태 변경용)
+scwin.btn_approve_complete_onclick = function () {
+    // 관리자만 사용 가능
+    if (scwin.employee.role === "실무자") {
+        Swal.fire({
+            title: '권한 없음',
+            text: '관리자만 결재 완료를 할 수 있습니다.',
+            icon: 'warning',
+            confirmButtonText: '확인',
+            confirmButtonColor: '#3085d6'
+        });
+        return;
+    }
+
+    // 결재중 상태가 아니면 비활성화
+    if (scwin.claim.status !== "결재중") {
+        Swal.fire({
+            title: '작업 불가',
+            text: '결재중 상태에서만 결재 완료가 가능합니다.',
+            icon: 'warning',
+            confirmButtonText: '확인',
+            confirmButtonColor: '#3085d6'
+        });
+        return;
+    }
+
+    if (!scwin.claim.claimNo) {
+        Swal.fire({
+            title: '오류',
+            text: '청구번호가 없습니다.',
+            icon: 'error',
+            confirmButtonText: '확인',
+            confirmButtonColor: '#3085d6'
+        });
+        return;
+    }
+
+    Swal.fire({
+        title: '결재 승인',
+        html: '결재를 승인하시겠습니까?<br><br>' +
+            '• 청구번호: ' + scwin.claim.claimNo + '<br>' +
+            '• 담당자: ' + (scwin.employee.empName || '관리자'),
+        icon: 'question',
+        showCancelButton: true,
+        confirmButtonColor: '#28a745',
+        cancelButtonColor: '#d33',
+        confirmButtonText: '승인',
+        cancelButtonText: '취소'
+    }).then((result) => {
+        if (result.isConfirmed) {
+            scwin.showLoading(true);
+            
+            // CLAIM 테이블의 status를 "결재완료"로 변경하는 요청
+            dma_approvalReq.set("claim_no", scwin.claim.claimNo);
+            dma_approvalReq.set("approval_memo", "관리자 결재 승인");
+            dma_approvalReq.set("request_type", "APPROVE");
+            
+            // 결재 승인 submission 실행
+            $p.executeSubmission("sbm_approveApprovalReq");
+        }
+    });
+};]]></script>
 	</head>
 	<body ev:onpageload="scwin.onpageload">
 		<w2:wframe style="z-index: 20;top: 0;width: 100%;" id="" src="/InsWebApp/ui/cmmn/header.xml"></w2:wframe>
@@ -2696,9 +2822,13 @@ scwin.checkApprovalPermission = function () {
 								<xf:label>결재신청</xf:label>
 							</xf:trigger>
 							<xf:trigger ev:onclick="scwin.btn_complete_onclick" style="width:100%;padding:16px;font-size:16px;" id="btn_complete"
-								type="button" class="btn_primary">
-								<xf:label>최종 심사 완료</xf:label>
+							type="button" class="btn_primary">
+							<xf:label>최종 심사 완료</xf:label>
 							</xf:trigger>
+						<xf:trigger ev:onclick="scwin.btn_approve_complete_onclick" style="width:100%;padding:16px;font-size:16px;background-color:#28a745;" id="btn_approve_complete"
+							type="button" class="btn_primary">
+							<xf:label>결재 완료</xf:label>
+						</xf:trigger>
 
 						</xf:group>
 					</xf:group>


### PR DESCRIPTION
feat: 관리자 결재 완료 기능 및 권한 매트릭스 개선

- 관리자용 '결재 완료' 버튼 추가로 역할별 기능 분리
- 실무자 심사완료 권한 확대 (대기/결재반려/보완/반송 상태)
- 상태별 동적 권한 제어 및 UI 개선

## 주요 변경사항

###  새로운 기능
- 관리자 전용 '결재 완료' 버튼 추가
- 결재중 상태에서만 관리자 버튼 활성화
- 실무자 대기 상태에서 심사완료 가능

###  권한 시스템 개선  
- 역할별 버튼 표시/숨김 처리
- 상태별 세밀한 권한 제어
- 관리자/실무자 기능 명확 분리

###  UI/UX 개선
- SweetAlert2로 일관된 사용자 알림
- 로딩 상태 관리 개선
- 버튼 비활성화 시각적 피드백

###  사용자 경험
- 로컬스토리지 상태 동기화
- 권한별 직관적 인터페이스
- 업무 프로세스 유연성 향상

## 기술적 세부사항

###  권한 매트릭스
**실무자 (본인 청구건)**
- 대기: 모든 작업 + 심사완료 
- 결재반려: 모든 작업 + 심사완료 
- 보완/반송: 제한적 작업 + 심사완료 

**관리자**
- 결재중: 결재완료/반려 활성화 
- 기타 상태: 모든 버튼 비활성화 
