### PR TITLE
feat: 약관 화면 추가 및 자동배정 UI 개선, 심사 권한 로직 수정

### DIFF
--- a/src/main/webapp/ui/Assignment/assignment.xml
+++ b/src/main/webapp/ui/Assignment/assignment.xml
@@ -804,8 +804,8 @@ scwin.sbm_previewAssignment_submitdone = function (e) {
             </xf:group>
             
             <!-- Generator를 위한 별도 컨테이너 영역 -->
-            <xf:group id="rule_container" style="width:100%; padding:20px;">
-                <w2:generator id="rule_gen" style="width:100%;">
+            <xf:group id="rule_container" style="padding:20px;">
+                <w2:generator id="rule_gen" style="">
                     <xf:group id="rule_item" style="width:100%; margin-bottom:15px; padding:20px; border:1px solid #e0e0e0; border-radius:8px; background-color:#ffffff; box-shadow: 0 2px 4px rgba(0,0,0,0.1); box-sizing:border-box;">
                         <xf:group style="display:flex; justify-content:space-between; align-items:flex-start; width:100%;">
                             <xf:group style="flex:1; min-width:0; padding-right:10px;">
@@ -821,10 +821,10 @@ scwin.sbm_previewAssignment_submitdone = function (e) {
                                 </xf:group>
                             </xf:group>
                             <xf:group style="display:flex; align-items:center; flex-shrink:0;">
-                                <xf:trigger class="" ev:onclick="scwin.item_edit_onclick" id="item_edit" style="width:50px; height:30px; margin-right:5px; font-size:13px;" type="button">
+                                <xf:trigger class="" ev:onclick="scwin.item_edit_onclick" id="item_edit" style="width:50px; height:30px; margin-right:5px; font-size:13px; border-radius: 10px;" type="button">
                                     <xf:label><![CDATA[수정]]></xf:label>
                                 </xf:trigger>
-                                <xf:trigger class="" ev:onclick="scwin.item_delete_onclick" id="item_delete" style="width:50px; height:30px; font-size:13px;" type="button">
+                                <xf:trigger class="" ev:onclick="scwin.item_delete_onclick" id="item_delete" style="width:50px; height:30px; font-size:13px; border-radius: 10px;" type="button">
                                     <xf:label><![CDATA[삭제]]></xf:label>
                                 </xf:trigger>
                             </xf:group>
@@ -834,7 +834,7 @@ scwin.sbm_previewAssignment_submitdone = function (e) {
             </xf:group>
             
             <!-- 추가 버튼 및 테스트 버튼 -->
-            <xf:group id="button_area" style="width:100%; text-align:right; padding:0 20px;">
+            <xf:group id="button_area" style="width:100%; text-align:right;">
                 <xf:trigger class="" ev:onclick="scwin.testBatchAssignment_onclick" id="test_batch" style="width:120px; height:35px; margin-right:10px;color:black;" type="button">
                     <xf:label><![CDATA[일괄 자동배정]]></xf:label>
                 </xf:trigger>

--- a/src/main/webapp/ui/Assignment/terms.xml
+++ b/src/main/webapp/ui/Assignment/terms.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:w2="http://www.inswave.com/websquare" xmlns:xf="http://www.w3.org/2002/xforms">
+    <head>
+        <w2:type>COMPONENT</w2:type>
+        <w2:buildDate/>
+        <w2:MSA/>
+        <xf:model>
+            <w2:dataCollection baseNode="map"/>
+            <w2:workflowCollection/>
+        </xf:model>
+        <w2:layoutInfo/>
+        <w2:publicInfo method=""/>
+        <script lazy="false" type="text/javascript"><![CDATA[
+scwin.onpageload = function() {
+	
+};
+]]></script>
+    </head>
+    <body ev:onpageload="scwin.onpageload">
+    	<xf:group class="sub_contents" id="" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true" meta_snippetName="0_01 페이지시작"
+    		style="">
+    		<xf:group class="pgtbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_01 페이지타이틀"
+    			style="">
+    			<w2:textbox class="pgt_tit" id="" label="제2장 회사가 보상하는 사항" style="" tagname=""></w2:textbox>
+    		</xf:group>
+    		<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+    			style="">
+    			<w2:textbox class="" id="" label="종합인원" style="" tagname="h3"></w2:textbox>
+    		</xf:group>
+    		<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+    			style="">
+    			<w2:textbox class="" id="" label="입원실료, 입원제비용, 입원수술비 :" style="" tagname="h4"></w2:textbox>
+    		</xf:group>
+    		<w2:span id=""
+    			label="'국민건강보험법에서 정한 요양급여 중 본인부담금'과 '비급여(상급병실료 차액 제외)' 부분의 합계액 중 90% 해당액(다만, 10% 해당액이 계약일 또는 매년 계약해당일로부터 연간 200만원을 초과하는 경우 그 초과금액은 보상합니다)"
+    			meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    		</w2:span>
+    		<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+    			style="margin-top: 10px;">
+    			<w2:textbox class="" id="" label="상급병실료 차액 :" style="" tagname="h4"></w2:textbox>
+    		</xf:group>
+    		<w2:span id=""
+    			label="입원시 실제 사용병실과 기준병실과의 병실료 차액 중 50%를 공제한 후의 금액(다만, 1일 평균금액 10만원을 한도로 하며, 1일 평균금액은 입원기간 동안 상급병실료 차액 전체를 총 입원일수로 나누어 산출합니다)"
+    			meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    		</w2:span>
+    		<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+    			style="margin-top: 10px;">
+    			<w2:textbox class="" id="" label="종합통원" style="" tagname="h3"></w2:textbox>
+    		</xf:group>
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span meta_snippetCategory="10_입력폼" meta_snippetName="10_16 출력텍스트" meta_snippetKeyComponent="true" style="" id=""
+    				label="방문 1회당 '국민건강보험법에서 정한 요양급여 중 본인부담금'과 '비급여' 부분의 합계액에서 ＜표1 항목별 공제금액＞을 차감하고 외래의 보험가입금액주)을 한도로 보상(매년 계약해당일로부터 1년간 방문 180회 한도)">
+    			</w2:span>
+    		</xf:group>
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span meta_snippetCategory="10_입력폼" meta_snippetName="10_16 출력텍스트" meta_snippetKeyComponent="true" style="" id=""
+    				label="주) 외래 및 처방조제비는 회(건)당 합산하여 30만원을 최고한도로 계약자가 정하는 금액으로 합니다.">
+    			</w2:span>
+    		</xf:group>
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span meta_snippetCategory="10_입력폼" meta_snippetName="10_16 출력텍스트" meta_snippetKeyComponent="true" style="" id=""
+    				label="&lt;표1 항목별 공제금액&gt;">
+    			</w2:span>
+    		</xf:group>
+    		<xf:group tagname="table" style="width:100%;" id="" class="w2tb">
+    			<w2:attributes>
+    				<w2:summary></w2:summary>
+    			</w2:attributes>
+    			<xf:group tagname="caption"></xf:group>
+    			<xf:group tagname="colgroup">
+    				<xf:group tagname="col" style="width:33.33%;"></xf:group>
+    				<xf:group tagname="col" style="width:33.33%;"></xf:group>
+    				<xf:group tagname="col" style="width:33.33%;"></xf:group>
+    			</xf:group>
+    			<xf:group tagname="tr" style="">
+    				<xf:group tagname="th" style="" class="w2tb_th">
+    					구분
+    					<w2:attributes>
+    						<w2:scope>col</w2:scope>
+    					</w2:attributes>
+    				</xf:group>
+    				<xf:group tagname="th" style="" class="w2tb_th">
+    					항목
+    					<w2:attributes>
+    						<w2:scope>col</w2:scope>
+    					</w2:attributes>
+    				</xf:group>
+    				<xf:group tagname="th" style="" class="w2tb_th">
+    					공제금액
+    					<w2:attributes>
+    						<w2:scope>col</w2:scope>
+    					</w2:attributes>
+    				</xf:group>
+    			</xf:group>
+    			<xf:group tagname="tr" style="">
+    				<xf:group tagname="td" style="" class="w2tb_td">
+    					외래
+    					<br></br>
+    					(외래제비용&amp;nbsp;및&amp;nbsp;외래수술비&amp;nbsp;합계)
+    				</xf:group>
+    				<xf:group tagname="td" style="" class="w2tb_td">
+    					의료법&amp;nbsp;제3조&amp;nbsp;제6항에&amp;nbsp;의한&amp;nbsp;의원,&amp;nbsp;치과의원,&amp;nbsp;한의원,&amp;nbsp;의료법&amp;nbsp;제3조&amp;nbsp;제7항에&amp;nbsp;의한&amp;nbsp;조산원,&amp;nbsp;지역보건법&amp;nbsp;제7조에&amp;nbsp;의한&amp;nbsp;보건소,&amp;nbsp;지역보건법&amp;nbsp;제8조에&amp;nbsp;의한&amp;nbsp;보건의료원,&amp;nbsp;지역보건법&amp;nbsp;제10조에&amp;nbsp;의한&amp;nbsp;보건지소,&amp;nbsp;농어촌&amp;nbsp;등&amp;nbsp;보건의료를&amp;nbsp;위한&amp;nbsp;특별조치법&amp;nbsp;제15조에&amp;nbsp;의한&amp;nbsp;보건진료소
+    				</xf:group>
+    				<xf:group tagname="td" style="" class="w2tb_td">1만원</xf:group>
+    			</xf:group>
+    			<xf:group tagname="tr" style="">
+    				<xf:group tagname="td" style="" class="w2tb_td">
+    					외래
+    					<br></br>
+    					(외래제비용&amp;nbsp;및&amp;nbsp;외래수술비&amp;nbsp;합계)
+    				</xf:group>
+    				<xf:group tagname="td" style="" class="w2tb_td">
+    					의료법&amp;nbsp;제3조&amp;nbsp;제3항에&amp;nbsp;의한&amp;nbsp;종합병원,&amp;nbsp;동법&amp;nbsp;제3조&amp;nbsp;제4항에&amp;nbsp;의한&amp;nbsp;병원,&amp;nbsp;치과병원,&amp;nbsp;한방병원,&amp;nbsp;동법&amp;nbsp;제3조&amp;nbsp;제5항에&amp;nbsp;의한&amp;nbsp;요양병원
+    				</xf:group>
+    				<xf:group tagname="td" style="" class="w2tb_td">1만5천원</xf:group>
+    			</xf:group>
+    			<xf:group tagname="tr" style="">
+    				<xf:group tagname="td" style="" class="w2tb_td">
+    					외래
+    					<br></br>
+    					(외래제비용&amp;nbsp;및&amp;nbsp;외래수술비&amp;nbsp;합계)
+    				</xf:group>
+    				<xf:group tagname="td" style="" class="w2tb_td">
+    					국민건강보험법&amp;nbsp;제40조&amp;nbsp;제2항에&amp;nbsp;의한&amp;nbsp;종합전문요양기관
+    				</xf:group>
+    				<xf:group tagname="td" style="" class="w2tb_td">2만원</xf:group>
+    			</xf:group>
+    		</xf:group>
+    		<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+    			style="margin-top: 10px;">
+    			<w2:textbox class="" id="" label="제3장 회사가 보상하지 않는 사항" style="" tagname="h3"></w2:textbox>
+    		</xf:group>
+    		
+    		<!-- 1번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span meta_snippetCategory="10_입력폼" meta_snippetName="10_16 출력텍스트" meta_snippetKeyComponent="true" style="" id=""
+    				label="1. 치과치료 및 한방치료에서 발생한 국민건강보험법상 요양급여에 해당하지 않는 비급여 의료비">
+    			</w2:span>
+    		</xf:group>
+    		
+    		<!-- 2번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="2. 국민건강보험법상 요양급여 중 본인부담금의 경우 국민건강보험 관련 법령에 의해 국민건강보험공단으로부터 사전 또는 사후 환급이 가능한 금액" 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    		</xf:group>
+    		
+    		<!-- 3번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="3. 건강검진, 예방접종, 인공유산. 다만, 회사가 보상하는 질병 치료를 목적으로 하는 경우에는 보상하여 드립니다." 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    		</xf:group>
+    		
+    		<!-- 4번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="4. 영양제, 종합비타민제, 호르몬 투여, 보신용 투약, 친자 확인을 위한 진단, 불임검사, 불임수술, 불임복원술, 보조생식술(체내, 체외 인공수정을 포함합니다), 성장촉진과 관련된 비용 등에 소요된 비용. 다만, 회사가 보상하는 질병 치료를 목적으로 하는 경우에는 보상하여 드립니다." 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    		</xf:group>
+    		
+    		<!-- 5번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="5. 아래에 열거된 치료로 인하여 발생한 의료비" 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    			<xf:group id="" style="margin-left: 20px; margin-bottom: 5px;">
+    				<w2:span id="" label="가. 단순한 피로 또는 권태" 
+    					meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    				</w2:span>
+    			</xf:group>
+    			<xf:group id="" style="margin-left: 20px; margin-bottom: 5px;">
+    				<w2:span id="" label="나. 주근깨, 다모, 무모, 백모증, 딸기코(주사비), 점(모반), 사마귀, 여드름, 노화현상으로 인한 탈모 등 피부질환" 
+    					meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    				</w2:span>
+    			</xf:group>
+    			<xf:group id="" style="margin-left: 20px; margin-bottom: 5px;">
+    				<w2:span id="" label="다. 발기부전(impotence)․불감증, 단순 코골음, 단순포경(phimosis), 검열반 등 안과질환" 
+    					meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    				</w2:span>
+    			</xf:group>
+    		</xf:group>
+    		
+    		<!-- 6번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="6. 의치, 의수족, 의안, 안경, 콘택트렌즈, 보청기, 목발, 팔걸이(Arm Sling), 보조기 등 진료재료의 구입 및 대체비용(다만, 인공장기나 부분 의치 등 신체에 이식되어 그 기능을 대신할 경우는 제외합니다)" 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    		</xf:group>
+    		
+    		<!-- 7번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="7. 외모개선 목적의 치료로 인하여 발생한 의료비" 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    			<xf:group id="" style="margin-left: 20px; margin-bottom: 5px;">
+    				<w2:span id="" label="가. 쌍꺼풀수술(이중검수술), 코성형수술(융비술), 유방확대·축소술, 지방흡입술, 주름살제거술 등" 
+    					meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    				</w2:span>
+    			</xf:group>
+    			<xf:group id="" style="margin-left: 20px; margin-bottom: 5px;">
+    				<w2:span id="" label="나. 사시교정, 안와격리증의 교정 등 시각계 수술로써 시력개선 목적이 아닌 외모개선 목적의 수술" 
+    					meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    				</w2:span>
+    			</xf:group>
+    			<xf:group id="" style="margin-left: 20px; margin-bottom: 5px;">
+    				<w2:span id="" label="다. 안경, 콘텍트렌즈 등을 대체하기 위한 시력교정술" 
+    					meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    				</w2:span>
+    			</xf:group>
+    			<xf:group id="" style="margin-left: 20px; margin-bottom: 5px;">
+    				<w2:span id="" label="라. 외모개선 목적의 다리정맥류 수술" 
+    					meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    				</w2:span>
+    			</xf:group>
+    		</xf:group>
+    		
+    		<!-- 8번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="8. 진료와 무관한 제비용(TV시청료, 전화료, 제증명료 등), 의사의 임상적 소견과 관련없는 검사비용" 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    		</xf:group>
+    		
+    		<!-- 9번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="9. 산재보험에서 보상받는 의료비. 다만, 본인부담의료비는 제3조(담보종목별 보장내용)에 따라 보상하여 드립니다." 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    		</xf:group>
+    		
+    		<!-- 10번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="10. 인간면역바이러스(HIV)감염으로 인한 치료비(단, 의료법에서 정한 의료인의 진료상 또는 치료중 혈액에 의한 HIV감염은 해당진료기록을 통해 객관적으로 확인되는 경우는 제외)"
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    		</xf:group>
+    		
+    		<!-- 11번 항목 -->
+    		<xf:group id="" style="margin-bottom: 10px;">
+    			<w2:span id="" label="11. 국내 의료법에 의한 치료를 목적으로 해외에서 발생한 의료비" 
+    				meta_snippetCategory="10_입력폼" meta_snippetKeyComponent="true" meta_snippetName="10_16 출력텍스트" style="">
+    			</w2:span>
+    		</xf:group>
+    		
+    	</xf:group>
+    </body>
+</html>

--- a/src/main/webapp/ui/audit/insure-result.xml
+++ b/src/main/webapp/ui/audit/insure-result.xml
@@ -2076,12 +2076,8 @@ scwin.setStatusStyle = function (status) {
 
 // 상태별 권한 설정 함수 추가
 scwin.setStatusBasedPermissions = function (status) {
-    console.log("상태별 권한 설정:", status);
 
     if (status === "결재중") {
-        // 결재중 상태: 보완, 반송 버튼 비활성화, 결재신청도 비활성화
-        console.log("결재중 상태 - 보완, 반송, 결재신청 비활성화");
-
         btn_supplement.setDisabled(true);
         btn_supplement.addClass("disabled-button");
 
@@ -2091,15 +2087,14 @@ scwin.setStatusBasedPermissions = function (status) {
         btn_approval.setDisabled(true);
         btn_approval.addClass("disabled-button");
 
-        // 메모 수정도 제한
-        txt_examMemo.setReadOnly(true);
-        txt_examMemo.addClass("readonly-textarea");
+        btn_complete.setDisabled(true);
+        btn_complete.addClass("disabled-button");
 
         btn_generateMemo.setDisabled(true);
         btn_generateMemo.addClass("disabled-button");
 
-        btn_complete.setDisabled(true);
-        btn_complete.addClass("disabled-button");
+        txt_examMemo.setReadOnly(true);
+        txt_examMemo.addClass("readonly-textarea");
     } else if (status === "결재완료") {
         // 결재완료 상태: 모든 수정 작업 비활성화, 완료 버튼만 활성화
         console.log("결재완료 상태 - 대부분의 작업 비활성화, 완료만 가능");
@@ -2172,10 +2167,31 @@ scwin.setStatusBasedPermissions = function (status) {
         txt_examMemo.setReadOnly(true);
         txt_examMemo.addClass("readonly-textarea");
 
-    } else if (status === "보완" || status === "반송") {
-        // 보완/반송 상태: 제한적 작업만 가능
-        console.log(status + " 상태 - 제한적 작업 가능");
+    }
+    else if(status === "보완"){
+           if (scwin.employee.role === "실무자" && scwin.claim.empNo === scwin.employee.empNo) {
+            // 보완/반송 상태에서는 재신청을 위한 작업만 가능
+            btn_supplement.setDisabled(true);
+            btn_supplement.addClass("disabled-button");
 
+            btn_return.setDisabled(true);
+            btn_return.addClass("disabled-button");
+
+            btn_approval.setDisabled(true);
+            btn_approval.addClass("disabled-button");
+
+            btn_complete.setDisabled(true);
+            btn_complete.addClass("disabled-button");
+
+            btn_generateMemo.setDisabled(true);
+            btn_generateMemo.addClass("disabled-button");
+
+            txt_examMemo.setReadOnly(true);
+            txt_examMemo.addClass("readonly-textarea");
+        }
+    }
+    
+     else if (status === "반송") {
         if (scwin.employee.role === "실무자" && scwin.claim.empNo === scwin.employee.empNo) {
             // 보완/반송 상태에서는 재신청을 위한 작업만 가능
             btn_supplement.setDisabled(true);
@@ -2184,18 +2200,17 @@ scwin.setStatusBasedPermissions = function (status) {
             btn_return.setDisabled(true);
             btn_return.addClass("disabled-button");
 
-            // 결재신청과 메모 생성, 심사완룼도 가능
-            btn_approval.setDisabled(false);
-            btn_approval.removeClass("disabled-button");
+            btn_approval.setDisabled(true);
+            btn_approval.addClass("disabled-button");
 
-            btn_complete.setDisabled(false);  // 보완/반송 상태에서도 심사완료 가능
-            btn_complete.removeClass("disabled-button");
+            btn_complete.setDisabled(true);
+            btn_complete.addClass("disabled-button");
 
-            btn_generateMemo.setDisabled(false);
-            btn_generateMemo.removeClass("disabled-button");
+            btn_generateMemo.setDisabled(true);
+            btn_generateMemo.addClass("disabled-button");
 
-            txt_examMemo.setReadOnly(false);
-            txt_examMemo.removeClass("readonly-textarea");
+            txt_examMemo.setReadOnly(true);
+            txt_examMemo.addClass("readonly-textarea");
         }
 
     } else if (status === "대기") {


### PR DESCRIPTION
## 작업 내용

### 1. 새로운 약관 화면 추가 (`terms.xml`)
- 의료비 보상 약관 정보를 표시하는 새로운 화면 구성
- 제2장 회사가 보상하는 사항 (종합인원, 종합통원)
- 제3장 회사가 보상하지 않는 사항 (1~11번 항목)
- 각 항목별 독립적인 그룹 구조로 구성하여 가독성 향상

### 2. 자동배정 화면 UI 개선 (`assignment.xml`)
- Generator 컨테이너 영역 스타일 조정
  - `width: 100%` 제거하여 레이아웃 유연성 개선
  - padding 유지로 여백 일관성 확보
- 버튼 스타일 개선
  - 수정/삭제 버튼에 `border-radius: 10px` 추가로 모던한 UI 적용
- 버튼 영역 padding 조정으로 정렬 개선

### 3. 심사 결과 화면 권한 로직 정리 (`insure-result.xml`)
- "보완" 상태와 "반송" 상태의 권한 처리 로직 분리
- 각 상태별 버튼 비활성화 로직 명확화
- 불필요한 console.log 제거

## 주요 변경사항

- **신규 파일**: `src/main/webapp/ui/Assignment/terms.xml` 
- **UI 개선**: 자동배정 화면의 레이아웃 및 버튼 스타일
- **로직 개선**: 심사 상태별 권한 관리 코드 리팩토링
